### PR TITLE
Fixed annotated document dimensions.

### DIFF
--- a/packages/annotation/css/annotation.css
+++ b/packages/annotation/css/annotation.css
@@ -1,3 +1,7 @@
+#gd-pages .gd-wrapper > img {
+    max-width: unset !important;
+}
+
 #gd-header-logo {
 	background-image: url('../images/logo.png') !important;
 }
@@ -1054,4 +1058,9 @@ button {
     width: 400px;
     height: 250px;
     left: calc(50% - 200px);
+}
+
+.gd-page-image {
+    width: inherit !important;
+    height: inherit !important;
 }


### PR DESCRIPTION
**Problem:**
We have problem with proper alignment of the polyline annotation after re-opening annotated document, more details in: https://github.com/groupdocs-annotation/GroupDocs.Annotation-for-.NET-MVC/issues/50.

**Solution:**
Were added styles changes for more proper presentation of the annotated document.

**Screenshots:**
![image](https://user-images.githubusercontent.com/17431807/74157302-194bf580-4c29-11ea-9e81-b14a39166321.png)
